### PR TITLE
Handle REGISTER expires

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Code formatting
 Clang-format is used to format the code. The settings are stored in .clangformat. The format of external files, e.g.
 components/sip_client/include/boost/sml.hpp should not be changed. To run clang-format (e.g. version 12) over all files::
 
-  find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\)' -exec clang-format -style=file -i {} \;
+  find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\)' -exec clang-format -style=file -i {} \;
 
 Hardware
 --------

--- a/components/sip_client/include/sip_client/sip_sml_events.h
+++ b/components/sip_client/include/sip_client/sip_sml_events.h
@@ -28,6 +28,7 @@ struct ev_initiate_call
 };
 struct ev_200_ok
 {
+    const uint32_t contact_expires;
 };
 struct ev_183_session_progress
 {
@@ -69,5 +70,9 @@ struct ev_500_internal_server_error
 };
 
 struct ev_reply_timeout
+{
+};
+
+struct ev_reregister
 {
 };


### PR DESCRIPTION
Tested with fritzbox 7490 and firmware 7.27.

Now the expires reply to the REGISTER in the SIP OK packet is evaluated. The REGISTER is resent every (expires / 2) seconds.