### PR TITLE
Add minor improvements to native code and to be able to use freeswitch and register at sipgate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ Tested with:
 * AVM Fritzbox 7390
 * AVM Fritzbox 7490 (Firmware 7.27)
 * AVM Fritzbox 7590
+* local FreeSWITCH installation
 
 Programming
 -----------

--- a/components/sip_client/include/sip_client/sip_client_internal.h
+++ b/components/sip_client/include/sip_client/sip_client_internal.h
@@ -346,6 +346,9 @@ private:
             m_to_tag = packet.get_to_tag();
         }
 
+        /* TODO: only copy record route, when not empty */
+        m_record_route = packet.get_record_route();
+
         if ((reply == SipPacket::Status::UNAUTHORIZED_401) || (reply == SipPacket::Status::PROXY_AUTH_REQ_407))
         {
             m_sm.process_event(ev_401_unauthorized {});
@@ -586,6 +589,17 @@ private:
         {
             stream << "To: <" << to_uri << ">\r\n";
         }
+        if (command == "ACK")
+        {
+            for (auto it = std::crbegin(m_record_route); it != std::crend(m_record_route); ++it)
+            {
+                if (it->empty())
+                {
+                    continue;
+                }
+                stream << "Route: " << *it << "\r\n";
+            }
+        }
     }
 
     void send_sip_reply_header(const std::string& code, const SipPacket& packet, TxBufferT& stream)
@@ -697,6 +711,8 @@ private:
     std::string m_to_uri;
     std::string m_to_contact;
     std::string m_to_tag;
+
+    SipPacket::RecordRouteT m_record_route;
 
     uint32_t m_sip_sequence_number;
     uint32_t m_call_id;

--- a/components/sip_client/include/sip_client/sip_states.h
+++ b/components/sip_client/include/sip_client/sip_states.h
@@ -100,7 +100,7 @@ struct sip_states
             "registered"_s + event<ev_rx_invite> / action_rx_invite = "call_established"_s,
             "registered"_s + event<ev_start> / action_register_unauth = "waiting_for_auth_reply"_s,
             "calling"_s + event<ev_401_unauthorized> / action_send_invite = "calling"_s,
-            "calling"_s + event<ev_cancel_call> / action_cancel_call = "calling"_s,
+            "calling"_s + event<ev_cancel_call> / action_cancel_call = "cancelling"_s,
             "calling"_s + event<ev_183_session_progress> = "calling"_s,
             "calling"_s + event<ev_100_trying> = "calling"_s,
             "calling"_s + event<ev_200_ok> / action_call_established = "call_established"_s,
@@ -113,6 +113,8 @@ struct sip_states
             "call_established"_s + event<ev_200_ok> = X,
             "call_established"_s + event<ev_reregister> / action_retry_reregistered = "call_established"_s,
             "call_established"_s + event<ev_start> / action_register_unauth = "waiting_for_auth_reply"_s,
+            "cancelling"_s + event<ev_200_ok> = "cancelling"_s,
+            "cancelling"_s + event<ev_487_request_cancelled> / action_call_cancelled = "registered"_s,
             "calling"_s + event<ev_200_ok> = X);
     }
 };

--- a/native/esp_log.h
+++ b/native/esp_log.h
@@ -14,8 +14,8 @@ static inline void my_log(const char* level, const char* prefix, const char* fmt
     printf("\n");
 }
 
-#define ESP_LOGE(prefix, fmt, ...) my_log("[ERR] ", prefix, fmt, ##__VA_ARGS__)
-#define ESP_LOGW(prefix, fmt, ...) my_log("[WARN] ", prefix, fmt, ##__VA_ARGS__)
-#define ESP_LOGI(prefix, fmt, ...) my_log("[INFO] ", prefix, fmt, ##__VA_ARGS__)
-#define ESP_LOGD(prefix, fmt, ...) my_log("[DBG] ", prefix, fmt, ##__VA_ARGS__)
-#define ESP_LOGV(prefix, fmt, ...) my_log("[VER] ", prefix, fmt, ##__VA_ARGS__)
+#define ESP_LOGE(prefix, fmt, ...) my_log("ERR", prefix, fmt, ##__VA_ARGS__)
+#define ESP_LOGW(prefix, fmt, ...) my_log("WARN", prefix, fmt, ##__VA_ARGS__)
+#define ESP_LOGI(prefix, fmt, ...) my_log("INFO", prefix, fmt, ##__VA_ARGS__)
+#define ESP_LOGD(prefix, fmt, ...) my_log("DBG", prefix, fmt, ##__VA_ARGS__)
+#define ESP_LOGV(prefix, fmt, ...) my_log("VER", prefix, fmt, ##__VA_ARGS__)

--- a/native/keyboard_input.h
+++ b/native/keyboard_input.h
@@ -1,0 +1,63 @@
+/*
+   Copyright Christian Taedcke <hacking@taedcke.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <termios.h>
+
+class KeyboardInput
+{
+public:
+    KeyboardInput(asio::io_context& io_context)
+        : stream { io_context, ::dup(STDIN_FILENO) }
+    {
+        struct termios current;
+        tcgetattr(0, &old_termios);
+        current = old_termios;
+        current.c_lflag &= ~ICANON; /* disable buffered i/o */
+        tcsetattr(0, TCSANOW, &current);
+    }
+
+    ~KeyboardInput()
+    {
+        tcsetattr(0, TCSANOW, &old_termios);
+    }
+
+    void do_read(std::function<void(char c)> on_press)
+    {
+        asio::async_read(
+            stream, asio::buffer(buf),
+            [this, on_press](std::error_code ec, std::size_t len) {
+                if (ec)
+                {
+                    ESP_LOGE(TAG, "exit with %s", ec.message().c_str());
+                }
+                else
+                {
+                    if ((len == 1) && on_press)
+                    {
+                        on_press(buf[0]);
+                    }
+                    do_read(on_press);
+                }
+            });
+    }
+
+private:
+    asio::posix::stream_descriptor stream;
+    std::array<char, 1> buf;
+    struct termios old_termios;
+
+    static constexpr char const* TAG = "key";
+};


### PR DESCRIPTION
Native Code:

- press c to initiate a call
- press d to cancel request
- press q to exit program

Sip implementation:

- add Route information to SIP ACK to be able to ACK some packets from sipgate properly

Overall status:

- tested a little bit with basic freeswitch installation
- sipgate (from native client)
  - registering seems to work
  - initiating a call seems to work
  - other stuff does not work, because sip implementation is very basic and has to be refactored before supporting more
    - sipgate does not send DTMF key presses as SIP INFO, but in the RSTP stream, so it is not working  