### PR TITLE
actuator: Fix active low config

### DIFF
--- a/main/Kconfig.actuator
+++ b/main/Kconfig.actuator
@@ -13,12 +13,13 @@ config ACTUATOR_OUTPUT_GPIO
             GPIO number (IOxx) to trigger the actuator for e.g. a door opener
             GPIOs 35-39 are input-only so cannot be used as outputs.
 
-config ACTUATOR_ACTIVE_HIGH
-    bool "Actuator output active high type"
-        default y
+config ACTUATOR_ACTIVE_LEVEL
+    int "Actuator output active level"
+        default 1
+        range 0 1
         help
-            This is about the hardware configuration of your setup. Active high (true) means the actuator is set to true/high when it is triggered.
-            Active low (false) means the actuator is set to false/low when it is triggered.
+            This is about the hardware configuration of your setup. Active high (1) means the actuator is set to true/high when it is triggered.
+            Active low (0) means the actuator is set to false/low when it is triggered.
 
 config ACTUATOR_SWITCHING_DURATION
     int "Actuator switching duration in milliseconds"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -191,7 +191,7 @@ static void sip_task(void* pvParameters)
         SipEventHandlerButton { *ctx->button_input_handler },
 #ifdef CONFIG_ACTUATOR_ENABLED
         SipEventHandlerActuator<static_cast<gpio_num_t>(CONFIG_ACTUATOR_OUTPUT_GPIO),
-            CONFIG_ACTUATOR_ACTIVE_HIGH,
+            CONFIG_ACTUATOR_ACTIVE_LEVEL,
             CONFIG_ACTUATOR_SWITCHING_DURATION,
             CONFIG_ACTUATOR_PHONE_BUTTON[0]> {},
 #endif /* ACTUATOR_ENABLED */


### PR DESCRIPTION
Before this commit it was not possible to configure active low actuator, see #30.

This commit changes the boolean Kconfig symbol
ACTUATOR_ACTIVE_HIGH (where CONFIG_ACTUATOR_ACTIVE_HIGH is not defined for active low config) to the integer Kconfig value ACTUATOR_ACTIVE_LEVEL, which is always defined, either to 1 or to 0. This way there is no need for ifdefs in the c++ code.

This fixes #30 and makes #32 obsolete.