### PR TITLE
Update to esp-idf 4.4.2 and fix workflow for main branch

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,9 +2,9 @@ name: Compile Project
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   setup:

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Programming
 
 The source code is mixed C and C++.
 
-This application is to be used with `Espressif IoT Development Framework`_ (ESP-IDF). It is tested with version v4.3.1 (rev 2e74914051d14ec2290fc751a8486fb51d73a31e)
+This application is to be used with `Espressif IoT Development Framework`_ (ESP-IDF). It is tested with version v4.4.2 (rev 1b16ef6cfc2479a08136782f9dc57effefa86f66)
 
 Please check ESP-IDF docs for getting started instructions.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:release-v4.3
+FROM espressif/idf:release-v4.4
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
There is no code change required, so just the Dockerfile used on the build server is updated and the README to docuent the latest stable esp-idf version.