### PR TITLE
Update clang, asio and esp-idf to some 5.0 dev version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,4 +14,7 @@ BraceWrapping:
   BeforeElse:      true
   IndentBraces:    false
 BreakBeforeBraces: Custom
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: 1
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,555 +1,299 @@
-# Created for/with clang-tidy-12
+# Created for/with clang-tidy-15
 # Call with run-clang-tidy.py anfter creating a compilation database
 ---
-Checks:          'bugprone-*,cert-*,clang-diagnostic-*,clang-analyzer-*,concurrency-mt-unsafe,cppcoreguidelines-*,hicpp-*,llvm-else-after-return,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-vararg,-hicpp-vararg,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-hicpp-no-array-decay,-cppcoreguidelines-macro-usage,-cert-dcl50-cpp'
-WarningsAsErrors: ''
+Checks:          'bugprone-*,cert-*,clang-diagnostic-*,clang-analyzer-*,concurrency-mt-unsafe,cppcoreguidelines-*,hicpp-*,llvm-else-after-return,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-vararg,-hicpp-vararg,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-hicpp-no-array-decay,-cppcoreguidelines-macro-usage,-cert-dcl50-cpp,-readability-identifier-length,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cert-msc30-c,-cert-msc50-cpp,-bugprone-easily-swappable-parameters,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-hicpp-signed-bitwise'
+WarningsAsErrors: 'misc-const-correctness,modernize-use-default-member-init,cppcoreguidelines-pro-type-member-init,hicpp-member-init,hicpp-explicit-conversions,cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,performance-unnecessary-value-param'
 # do not match smp.hpp
 # all other headers are *.h
 HeaderFilterRegex: '.*\.h$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
-  - key:             cert-msc32-c.DisallowedSeedTypes
-    value:           'time_t,std::time_t'
-  - key:             cppcoreguidelines-no-malloc.Reallocations
-    value:           '::realloc'
-  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
-    value:           '::free;::realloc;::freopen;::fclose'
-  - key:             bugprone-reserved-identifier.Invert
-    value:           'false'
-  - key:             bugprone-narrowing-conversions.PedanticMode
-    value:           'false'
-  - key:             altera-struct-pack-align.MaxConfiguredAlignment
-    value:           '128'
-  - key:             bugprone-unused-return-value.CheckedFunctions
-    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty;::std::back_inserter;::std::distance;::std::find;::std::find_if;::std::inserter;::std::lower_bound;::std::make_pair;::std::map::count;::std::map::find;::std::map::lower_bound;::std::multimap::equal_range;::std::multimap::upper_bound;::std::set::count;::std::set::find;::std::setfill;::std::setprecision;::std::setw;::std::upper_bound;::std::vector::at;::bsearch;::ferror;::feof;::isalnum;::isalpha;::isblank;::iscntrl;::isdigit;::isgraph;::islower;::isprint;::ispunct;::isspace;::isupper;::iswalnum;::iswprint;::iswspace;::isxdigit;::memchr;::memcmp;::strcmp;::strcoll;::strncmp;::strpbrk;::strrchr;::strspn;::strstr;::wcscmp;::access;::bind;::connect;::difftime;::dlsym;::fnmatch;::getaddrinfo;::getopt;::htonl;::htons;::iconv_open;::inet_addr;::isascii;::isatty;::mmap;::newlocale;::openat;::pathconf;::pthread_equal;::pthread_getspecific;::pthread_mutex_trylock;::readdir;::readlink;::recvmsg;::regexec;::scandir;::semget;::setjmp;::shm_open;::shmget;::sigismember;::strcasecmp;::strsignal;::ttyname'
-  - key:             modernize-use-auto.MinTypeNameLength
-    value:           '5'
-  - key:             cert-dcl51-cpp.AggressiveDependentMemberLookup
-    value:           'false'
-  - key:             hicpp-use-auto.MinTypeNameLength
-    value:           '5'
-  - key:             readability-inconsistent-declaration-parameter-name.Strict
-    value:           'false'
-  - key:             hicpp-use-override.IgnoreDestructors
-    value:           'false'
-  - key:             cppcoreguidelines-macro-usage.CheckCapsOnly
-    value:           'false'
-  - key:             cert-dcl37-c.AllowedIdentifiers
-    value:           ''
-  - key:             hicpp-use-emplace.SmartPointers
-    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
-  - key:             hicpp-member-init.IgnoreArrays
-    value:           'false'
-  - key:             openmp-exception-escape.IgnoredExceptions
-    value:           ''
-  - key:             hicpp-use-override.AllowOverrideAndFinal
-    value:           'false'
-  - key:             abseil-string-find-str-contains.StringLikeClasses
-    value:           '::std::basic_string;::std::basic_string_view;::absl::string_view'
-  - key:             android-comparison-in-temp-failure-retry.RetryMacros
-    value:           TEMP_FAILURE_RETRY
-  - key:             hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
-    value:           'false'
-  - key:             cert-err09-cpp.WarnOnLargeObjects
-    value:           'false'
-  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
-    value:           'true'
-  - key:             bugprone-argument-comment.CommentNullPtrs
-    value:           '0'
-  - key:             cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion
-    value:           'true'
-  - key:             hicpp-use-equals-delete.IgnoreMacros
-    value:           'true'
-  - key:             cppcoreguidelines-init-variables.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-nodiscard.ReplacementString
-    value:           '[[nodiscard]]'
-  - key:             modernize-loop-convert.MakeReverseRangeHeader
-    value:           ''
-  - key:             misc-definitions-in-headers.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             hicpp-uppercase-literal-suffix.NewSuffixes
-    value:           ''
-  - key:             performance-move-constructor-init.IncludeStyle
-    value:           llvm
-  - key:             modernize-loop-convert.UseCxx20ReverseRanges
-    value:           'true'
-  - key:             hicpp-function-size.VariableThreshold
-    value:           '4294967295'
-  - key:             cert-oop57-cpp.MemSetNames
-    value:           ''
-  - key:             hicpp-no-malloc.Deallocations
-    value:           '::free'
-  - key:             performance-type-promotion-in-math-fn.IncludeStyle
-    value:           llvm
-  - key:             google-readability-function-size.LineThreshold
-    value:           '4294967295'
-  - key:             bugprone-suspicious-include.ImplementationFileExtensions
-    value:           'c;cc;cpp;cxx'
-  - key:             modernize-loop-convert.MakeReverseRangeFunction
-    value:           ''
-  - key:             bugprone-suspicious-missing-comma.SizeThreshold
-    value:           '5'
-  - key:             readability-inconsistent-declaration-parameter-name.IgnoreMacros
-    value:           'true'
-  - key:             readability-identifier-naming.IgnoreFailedSplit
-    value:           'false'
-  - key:             hicpp-multiway-paths-covered.WarnOnMissingElse
-    value:           'false'
-  - key:             readability-qualified-auto.AddConstToQualified
-    value:           'true'
-  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
-    value:           'true'
-  - key:             bugprone-string-constructor.WarnOnLargeLength
-    value:           'true'
-  - key:             hicpp-no-malloc.Allocations
-    value:           '::malloc;::calloc'
-  - key:             cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
-    value:           override
-  - key:             hicpp-use-noexcept.UseNoexceptFalse
-    value:           'true'
-  - key:             abseil-string-find-startswith.IncludeStyle
-    value:           llvm
-  - key:             google-global-names-in-headers.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             readability-uppercase-literal-suffix.IgnoreMacros
-    value:           'true'
-  - key:             cert-dcl59-cpp.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             bugprone-dynamic-static-initializers.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             modernize-make-shared.IgnoreMacros
-    value:           'true'
-  - key:             bugprone-suspicious-enum-usage.StrictMode
-    value:           'false'
-  - key:             performance-unnecessary-copy-initialization.AllowedTypes
-    value:           ''
-  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
-    value:           '5'
-  - key:             modernize-use-transparent-functors.SafeMode
-    value:           'false'
-  - key:             bugprone-not-null-terminated-result.WantToUseSafeFunctions
-    value:           'true'
-  - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
-    value:           'true'
-  - key:             bugprone-string-constructor.LargeLengthThreshold
-    value:           '8388608'
-  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
-    value:           'false'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues
-    value:           'false'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           'false'
-  - key:             cert-err09-cpp.CheckThrowTemporaries
-    value:           'true'
-  - key:             performance-inefficient-vector-operation.EnableProto
-    value:           'false'
-  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
-    value:           ''
-  - key:             modernize-loop-convert.MaxCopySize
-    value:           '16'
-  - key:             bugprone-argument-comment.CommentStringLiterals
-    value:           '0'
-  - key:             google-build-namespaces.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             portability-simd-intrinsics.Suggest
-    value:           'false'
-  - key:             modernize-make-shared.MakeSmartPtrFunction
-    value:           'std::make_shared'
-  - key:             readability-function-size.LineThreshold
-    value:           '4294967295'
-  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
-    value:           ''
-  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
-    value:           '<memory>'
-  - key:             modernize-use-override.IgnoreDestructors
-    value:           'false'
-  - key:             misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
-    value:           'false'
-  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
-    value:           'true'
-  - key:             readability-redundant-string-init.StringNames
-    value:           '::std::basic_string_view;::std::basic_string'
-  - key:             modernize-make-unique.IgnoreDefaultInitialization
-    value:           'true'
-  - key:             modernize-use-emplace.ContainersWithPushBack
-    value:           '::std::vector;::std::list;::std::deque'
-  - key:             readability-magic-numbers.IgnoreBitFieldsWidths
-    value:           'true'
-  - key:             modernize-make-unique.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-override.OverrideSpelling
-    value:           override
-  - key:             google-readability-function-size.NestingThreshold
-    value:           '4294967295'
-  - key:             concurrency-mt-unsafe.FunctionSet
-    value:           any
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             bugprone-reserved-identifier.AllowedIdentifiers
-    value:           ''
-  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
-    value:           'false'
-  - key:             readability-else-after-return.WarnOnUnfixable
-    value:           'true'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
-    value:           '1.0;100.0;'
-  - key:             modernize-use-emplace.IgnoreImplicitConstructors
-    value:           'false'
-  - key:             cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
-    value:           'true'
-  - key:             modernize-use-equals-delete.IgnoreMacros
-    value:           'true'
-  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
-    value:           llvm
-  - key:             objc-forbidden-subclassing.ForbiddenSuperClassNames
-    value:           'ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView'
-  - key:             readability-magic-numbers.IgnoreAllFloatingPointValues
-    value:           'false'
-  - key:             hicpp-use-auto.RemoveStars
-    value:           'false'
-  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
-    value:           'false'
-  - key:             readability-uppercase-literal-suffix.NewSuffixes
-    value:           ''
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             performance-unnecessary-value-param.AllowedTypes
-    value:           ''
-  - key:             misc-definitions-in-headers.UseHeaderFileExtension
-    value:           'true'
-  - key:             misc-throw-by-value-catch-by-reference.MaxSize
-    value:           '64'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues
-    value:           'false'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoreBitFieldsWidths
-    value:           'true'
-  - key:             cert-err61-cpp.CheckThrowTemporaries
-    value:           'true'
-  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
-    value:           '1;2;3;4;'
-  - key:             cppcoreguidelines-no-malloc.Allocations
-    value:           '::malloc;::calloc'
-  - key:             readability-function-size.BranchThreshold
-    value:           '4294967295'
-  - key:             bugprone-suspicious-missing-comma.RatioThreshold
-    value:           '0.200000'
-  - key:             hicpp-function-size.LineThreshold
-    value:           '4294967295'
-  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
-    value:           'false'
-  - key:             readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             hicpp-use-noexcept.ReplacementString
-    value:           ''
-  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
-    value:           'false'
-  - key:             cppcoreguidelines-init-variables.MathHeader
-    value:           '<math.h>'
-  - key:             google-runtime-int.SignedTypePrefix
-    value:           int
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             cert-msc51-cpp.DisallowedSeedTypes
-    value:           'time_t,std::time_t'
-  - key:             hicpp-use-emplace.TupleMakeFunctions
-    value:           '::std::make_pair;::std::make_tuple'
-  - key:             bugprone-reserved-identifier.AggressiveDependentMemberLookup
-    value:           'false'
-  - key:             modernize-use-equals-default.IgnoreMacros
-    value:           'true'
-  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
-    value:           'false'
-  - key:             cert-dcl37-c.AggressiveDependentMemberLookup
-    value:           'false'
-  - key:             abseil-string-find-str-contains.AbseilStringsMatchHeader
-    value:           'absl/strings/match.h'
-  - key:             bugprone-dangling-handle.HandleClasses
-    value:           'std::basic_string_view;std::experimental::basic_string_view'
-  - key:             modernize-use-emplace.SmartPointers
-    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
-  - key:             cppcoreguidelines-no-malloc.Deallocations
-    value:           '::free'
-  - key:             readability-magic-numbers.IgnorePowersOf2IntegerValues
-    value:           'false'
-  - key:             misc-unused-parameters.StrictMode
-    value:           'false'
-  - key:             cert-oop11-cpp.IncludeStyle
-    value:           llvm
-  - key:             readability-simplify-subscript-expr.Types
-    value:           '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
-    value:           'true'
-  - key:             hicpp-move-const-arg.CheckTriviallyCopyableMove
-    value:           'true'
-  - key:             readability-function-size.VariableThreshold
-    value:           '4294967295'
-  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
-    value:           '3'
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             bugprone-narrowing-conversions.WarnOnFloatingPointNarrowingConversion
-    value:           'true'
-  - key:             readability-identifier-naming.GetConfigPerFile
-    value:           'true'
-  - key:             cert-err61-cpp.MaxSize
-    value:           '64'
-  - key:             hicpp-member-init.UseAssignment
-    value:           'false'
-  - key:             modernize-use-default-member-init.UseAssignment
-    value:           'false'
-  - key:             readability-function-size.NestingThreshold
-    value:           '4294967295'
-  - key:             google-readability-function-size.BranchThreshold
-    value:           '4294967295'
-  - key:             llvm-namespace-comment.ShortNamespaceLines
-    value:           '1'
-  - key:             llvm-namespace-comment.SpacesBeforeComments
-    value:           '1'
-  - key:             modernize-use-override.AllowOverrideAndFinal
-    value:           'false'
-  - key:             readability-function-size.ParameterThreshold
-    value:           '4294967295'
-  - key:             hicpp-function-size.NestingThreshold
-    value:           '4294967295'
-  - key:             modernize-pass-by-value.ValuesOnly
-    value:           'false'
-  - key:             modernize-loop-convert.IncludeStyle
-    value:           llvm
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           'false'
-  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
-    value:           'false'
-  - key:             cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
-    value:           'false'
-  - key:             hicpp-braces-around-statements.ShortStatementLines
-    value:           '0'
-  - key:             readability-redundant-smartptr-get.IgnoreMacros
-    value:           'true'
-  - key:             google-readability-function-size.ParameterThreshold
-    value:           '4294967295'
-  - key:             readability-identifier-naming.AggressiveDependentMemberLookup
-    value:           'false'
-  - key:             cert-err61-cpp.WarnOnLargeObjects
-    value:           'false'
-  - key:             modernize-use-emplace.TupleTypes
-    value:           '::std::pair;::std::tuple'
-  - key:             hicpp-use-emplace.IgnoreImplicitConstructors
-    value:           'false'
-  - key:             modernize-use-emplace.TupleMakeFunctions
-    value:           '::std::make_pair;::std::make_tuple'
-  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
-    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
-  - key:             hicpp-uppercase-literal-suffix.IgnoreMacros
-    value:           'true'
-  - key:             bugprone-argument-comment.StrictMode
-    value:           '0'
-  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           'false'
-  - key:             modernize-replace-random-shuffle.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-bool-literals.IgnoreMacros
-    value:           'true'
-  - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
-    value:           'true'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             hicpp-use-override.OverrideSpelling
-    value:           override
-  - key:             modernize-avoid-bind.PermissiveParameterList
-    value:           'false'
-  - key:             modernize-use-override.FinalSpelling
-    value:           final
-  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
-    value:           ''
-  - key:             cert-err09-cpp.MaxSize
-    value:           '64'
-  - key:             hicpp-use-equals-default.IgnoreMacros
-    value:           'true'
-  - key:             modernize-use-noexcept.ReplacementString
-    value:           ''
-  - key:             modernize-use-using.IgnoreMacros
-    value:           'true'
-  - key:             hicpp-use-override.FinalSpelling
-    value:           final
-  - key:             cppcoreguidelines-explicit-virtual-functions.FinalSpelling
-    value:           final
-  - key:             modernize-loop-convert.NamingStyle
-    value:           CamelCase
-  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
-    value:           'false'
-  - key:             bugprone-suspicious-include.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             hicpp-function-size.StatementThreshold
-    value:           '800'
-  - key:             performance-for-range-copy.WarnOnAllAutoCopies
-    value:           'false'
-  - key:             hicpp-no-malloc.Reallocations
-    value:           '::realloc'
-  - key:             google-runtime-int.UnsignedTypePrefix
-    value:           uint
-  - key:             bugprone-argument-comment.CommentCharacterLiterals
-    value:           '0'
-  - key:             bugprone-argument-comment.CommentIntegerLiterals
-    value:           '0'
-  - key:             performance-no-automatic-move.AllowedTypes
-    value:           ''
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             bugprone-argument-comment.CommentFloatLiterals
-    value:           '0'
-  - key:             bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit
-    value:           '16'
-  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
-    value:           'false'
-  - key:             abseil-string-find-startswith.AbseilStringsMatchHeader
-    value:           'absl/strings/match.h'
-  - key:             readability-else-after-return.WarnOnConditionVariables
-    value:           'true'
-  - key:             modernize-use-nullptr.NullMacros
-    value:           'NULL'
-  - key:             cppcoreguidelines-macro-usage.AllowedRegexp
-    value:           '^DEBUG_*'
-  - key:             llvm-header-guard.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             cppcoreguidelines-narrowing-conversions.PedanticMode
-    value:           'false'
-  - key:             modernize-make-shared.IgnoreDefaultInitialization
-    value:           'true'
-  - key:             modernize-make-shared.IncludeStyle
-    value:           llvm
-  - key:             hicpp-special-member-functions.AllowMissingMoveFunctions
-    value:           'false'
-  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
-    value:           'false'
-  - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
-    value:           ''
-  - key:             cert-dcl51-cpp.Invert
-    value:           'false'
-  - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
-    value:           'false'
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           'true'
-  - key:             modernize-make-unique.IgnoreMacros
-    value:           'true'
-  - key:             performance-for-range-copy.AllowedTypes
-    value:           ''
-  - key:             hicpp-function-size.BranchThreshold
-    value:           '4294967295'
-  - key:             bugprone-argument-comment.CommentBoolLiterals
-    value:           '0'
-  - key:             readability-braces-around-statements.ShortStatementLines
-    value:           '0'
-  - key:             bugprone-argument-comment.CommentUserDefinedLiterals
-    value:           '0'
-  - key:             hicpp-use-emplace.ContainersWithPushBack
-    value:           '::std::vector;::std::list;::std::deque'
-  - key:             abseil-string-find-startswith.StringLikeClasses
-    value:           '::std::basic_string'
-  - key:             hicpp-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
-    value:           'false'
-  - key:             performance-inefficient-string-concatenation.StrictMode
-    value:           'false'
-  - key:             readability-implicit-bool-conversion.AllowPointerConditions
-    value:           'false'
-  - key:             readability-magic-numbers.IgnoredFloatingPointValues
-    value:           '1.0;100.0;'
-  - key:             readability-redundant-declaration.IgnoreMacros
-    value:           'true'
-  - key:             modernize-make-unique.MakeSmartPtrFunction
-    value:           'std::make_unique'
-  - key:             google-runtime-int.TypeSuffix
-    value:           ''
-  - key:             hicpp-function-size.ParameterThreshold
-    value:           '4294967295'
-  - key:             cert-dcl51-cpp.AllowedIdentifiers
-    value:           ''
-  - key:             portability-restrict-system-includes.Includes
-    value:           '*'
-  - key:             cert-oop57-cpp.MemCpyNames
-    value:           ''
-  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
-    value:           '<memory>'
-  - key:             zircon-temporary-objects.Names
-    value:           ''
-  - key:             hicpp-use-emplace.TupleTypes
-    value:           '::std::pair;::std::tuple'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables
-    value:           'false'
-  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
-    value:           'false'
-  - key:             cert-oop57-cpp.MemCmpNames
-    value:           ''
-  - key:             modernize-use-noexcept.UseNoexceptFalse
-    value:           'true'
-  - key:             readability-function-cognitive-complexity.Threshold
-    value:           '25'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           'true'
-  - key:             bugprone-argument-comment.IgnoreSingleArgument
-    value:           '0'
-  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
-    value:           'false'
-  - key:             performance-faster-string-find.StringLikeClasses
-    value:           '::std::basic_string;::std::basic_string_view'
-  - key:             bugprone-assert-side-effect.CheckFunctionCalls
-    value:           'false'
-  - key:             google-readability-function-size.VariableThreshold
-    value:           '4294967295'
-  - key:             bugprone-string-constructor.StringNames
-    value:           '::std::basic_string;::std::basic_string_view'
-  - key:             bugprone-assert-side-effect.AssertMacros
-    value:           assert
-  - key:             bugprone-exception-escape.IgnoredExceptions
-    value:           ''
-  - key:             bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons
-    value:           'true'
-  - key:             modernize-use-default-member-init.IgnoreMacros
-    value:           'true'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           'false'
-  - key:             cert-str34-c.CharTypdefsToIgnore
-    value:           ''
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           'false'
-  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
-    value:           'true'
-  - key:             modernize-raw-string-literal.DelimiterStem
-    value:           lit
-  - key:             misc-throw-by-value-catch-by-reference.WarnOnLargeObjects
-    value:           'false'
-  - key:             cert-dcl37-c.Invert
-    value:           'false'
-  - key:             altera-single-work-item-barrier.AOCVersion
-    value:           '1600'
-  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
-    value:           'false'
-  - key:             readability-magic-numbers.IgnoredIntegerValues
-    value:           '1;2;3;4;'
-  - key:             modernize-use-auto.RemoveStars
-    value:           'false'
-  - key:             abseil-string-find-str-contains.IncludeStyle
-    value:           llvm
-  - key:             performance-inefficient-vector-operation.VectorLikeClasses
-    value:           '::std::vector'
-  - key:             portability-simd-intrinsics.Std
-    value:           ''
-  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
-    value:           'false'
-  - key:             hicpp-use-nullptr.NullMacros
-    value:           ''
-  - key:             cert-dcl16-c.IgnoreMacros
-    value:           'true'
-  - key:             performance-unnecessary-value-param.IncludeStyle
-    value:           llvm
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           'false'
-  - key:             modernize-replace-disallow-copy-and-assign-macro.MacroName
-    value:           DISALLOW_COPY_AND_ASSIGN
+  hicpp-move-const-arg.CheckMoveToConstRef: 'true'
+  readability-suspicious-call-argument.PrefixSimilarAbove: '30'
+  cppcoreguidelines-no-malloc.Reallocations: '::realloc'
+  cppcoreguidelines-owning-memory.LegacyResourceConsumers: '::free;::realloc;::freopen;::fclose'
+  modernize-use-auto.MinTypeNameLength: '5'
+  bugprone-reserved-identifier.Invert: 'false'
+  bugprone-narrowing-conversions.PedanticMode: 'false'
+  bugprone-unused-return-value.CheckedFunctions: '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty;::std::back_inserter;::std::distance;::std::find;::std::find_if;::std::inserter;::std::lower_bound;::std::make_pair;::std::map::count;::std::map::find;::std::map::lower_bound;::std::multimap::equal_range;::std::multimap::upper_bound;::std::set::count;::std::set::find;::std::setfill;::std::setprecision;::std::setw;::std::upper_bound;::std::vector::at;::bsearch;::ferror;::feof;::isalnum;::isalpha;::isblank;::iscntrl;::isdigit;::isgraph;::islower;::isprint;::ispunct;::isspace;::isupper;::iswalnum;::iswprint;::iswspace;::isxdigit;::memchr;::memcmp;::strcmp;::strcoll;::strncmp;::strpbrk;::strrchr;::strspn;::strstr;::wcscmp;::access;::bind;::connect;::difftime;::dlsym;::fnmatch;::getaddrinfo;::getopt;::htonl;::htons;::iconv_open;::inet_addr;::isascii;::isatty;::mmap;::newlocale;::openat;::pathconf;::pthread_equal;::pthread_getspecific;::pthread_mutex_trylock;::readdir;::readlink;::recvmsg;::regexec;::scandir;::semget;::setjmp;::shm_open;::shmget;::sigismember;::strcasecmp;::strsignal;::ttyname'
+  cert-dcl51-cpp.AggressiveDependentMemberLookup: 'false'
+  hicpp-use-auto.MinTypeNameLength: '5'
+  readability-inconsistent-declaration-parameter-name.Strict: 'false'
+  hicpp-use-override.IgnoreDestructors: 'false'
+  cert-dcl16-c.IgnoreMacros: 'true'
+  readability-suspicious-call-argument.DiceDissimilarBelow: '60'
+  cert-dcl37-c.AllowedIdentifiers: ''
+  hicpp-use-emplace.SmartPointers: '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  bugprone-assert-side-effect.IgnoredFunctions: __builtin_expect
+  hicpp-member-init.IgnoreArrays: 'false'
+  readability-suspicious-call-argument.Equality: 'true'
+  hicpp-use-override.AllowOverrideAndFinal: 'false'
+  misc-uniqueptr-reset-release.IncludeStyle: llvm
+  hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: 'false'
+  cert-err09-cpp.WarnOnLargeObjects: 'false'
+  bugprone-suspicious-string-compare.WarnOnImplicitComparison: 'true'
+  bugprone-argument-comment.CommentNullPtrs: '0'
+  cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion: 'true'
+  hicpp-use-equals-delete.IgnoreMacros: 'true'
+  cppcoreguidelines-init-variables.IncludeStyle: llvm
+  modernize-use-nodiscard.ReplacementString: '[[nodiscard]]'
+  modernize-loop-convert.MakeReverseRangeHeader: ''
+  readability-suspicious-call-argument.SuffixSimilarAbove: '30'
+  misc-definitions-in-headers.HeaderFileExtensions: ';h;hh;hpp;hxx'
+  hicpp-uppercase-literal-suffix.NewSuffixes: ''
+  cppcoreguidelines-narrowing-conversions.WarnOnIntegerNarrowingConversion: 'true'
+  modernize-loop-convert.UseCxx20ReverseRanges: 'true'
+  cppcoreguidelines-prefer-member-initializer.UseAssignment: 'false'
+  hicpp-function-size.VariableThreshold: '4294967295'
+  cert-oop57-cpp.MemSetNames: ''
+  hicpp-no-malloc.Deallocations: '::free'
+  performance-type-promotion-in-math-fn.IncludeStyle: llvm
+  readability-function-cognitive-complexity.DescribeBasicIncrements: 'true'
+  bugprone-suspicious-include.ImplementationFileExtensions: 'c;cc;cpp;cxx'
+  modernize-loop-convert.MakeReverseRangeFunction: ''
+  bugprone-suspicious-missing-comma.SizeThreshold: '5'
+  readability-inconsistent-declaration-parameter-name.IgnoreMacros: 'true'
+  readability-identifier-naming.IgnoreFailedSplit: 'false'
+  hicpp-multiway-paths-covered.WarnOnMissingElse: 'false'
+  readability-qualified-auto.AddConstToQualified: 'true'
+  bugprone-sizeof-expression.WarnOnSizeOfThis: 'true'
+  bugprone-string-constructor.WarnOnLargeLength: 'true'
+  hicpp-no-malloc.Allocations: '::malloc;::calloc'
+  cppcoreguidelines-explicit-virtual-functions.OverrideSpelling: override
+  hicpp-use-noexcept.UseNoexceptFalse: 'true'
+  readability-uppercase-literal-suffix.IgnoreMacros: 'true'
+  misc-const-correctness.TransformValues: 'true'
+  bugprone-dynamic-static-initializers.HeaderFileExtensions: ';h;hh;hpp;hxx'
+  cert-dcl59-cpp.HeaderFileExtensions: ';h;hh;hpp;hxx'
+  bugprone-suspicious-enum-usage.StrictMode: 'false'
+  performance-unnecessary-copy-initialization.AllowedTypes: ''
+  modernize-make-shared.IgnoreMacros: 'true'
+  readability-suspicious-call-argument.Levenshtein: 'true'
+  bugprone-suspicious-missing-comma.MaxConcatenatedTokens: '5'
+  modernize-use-transparent-functors.SafeMode: 'false'
+  misc-throw-by-value-catch-by-reference.CheckThrowTemporaries: 'true'
+  bugprone-not-null-terminated-result.WantToUseSafeFunctions: 'true'
+  bugprone-string-constructor.LargeLengthThreshold: '8388608'
+  readability-simplify-boolean-expr.ChainedConditionalAssignment: 'false'
+  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
+  cert-err09-cpp.CheckThrowTemporaries: 'true'
+  performance-inefficient-vector-operation.EnableProto: 'false'
+  bugprone-exception-escape.FunctionsThatShouldNotThrow: ''
+  modernize-loop-convert.MaxCopySize: '16'
+  readability-suspicious-call-argument.PrefixDissimilarBelow: '25'
+  modernize-make-shared.MakeSmartPtrFunction: 'std::make_shared'
+  hicpp-deprecated-headers.CheckHeaderFile: 'false'
+  readability-function-size.LineThreshold: '4294967295'
+  modernize-make-shared.MakeSmartPtrFunctionHeader: '<memory>'
+  modernize-use-override.IgnoreDestructors: 'false'
+  misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables: 'false'
+  bugprone-sizeof-expression.WarnOnSizeOfConstant: 'true'
+  readability-redundant-string-init.StringNames: '::std::basic_string_view;::std::basic_string'
+  modernize-make-unique.IgnoreDefaultInitialization: 'true'
+  modernize-use-emplace.ContainersWithPushBack: '::std::vector;::std::list;::std::deque'
+  modernize-make-unique.IncludeStyle: llvm
+  modernize-use-override.OverrideSpelling: override
+  readability-suspicious-call-argument.LevenshteinDissimilarBelow: '50'
+  bugprone-argument-comment.CommentStringLiterals: '0'
+  concurrency-mt-unsafe.FunctionSet: any
+  google-readability-braces-around-statements.ShortStatementLines: '1'
+  bugprone-reserved-identifier.AllowedIdentifiers: ''
+  cppcoreguidelines-pro-type-member-init.IgnoreArrays: 'false'
+  readability-else-after-return.WarnOnUnfixable: 'true'
+  modernize-use-emplace.IgnoreImplicitConstructors: 'false'
+  readability-suspicious-call-argument.Substring: 'true'
+  modernize-use-equals-delete.IgnoreMacros: 'true'
+  hicpp-use-auto.RemoveStars: 'false'
+  readability-suspicious-call-argument.Abbreviations: 'arr=array;cnt=count;idx=index;src=source;stmt=statement;cpy=copy;dest=destination;dist=distancedst=distance;ptr=pointer;wdth=width;str=string;ln=line;srv=server;attr=attribute;ref=reference;buf=buffer;col=column;nr=number;vec=vector;len=length;elem=element;val=value;i=index;var=variable;hght=height;cl=client;num=number;pos=position;lst=list;addr=address'
+  bugprone-misplaced-widening-cast.CheckImplicitCasts: 'false'
+  readability-uppercase-literal-suffix.NewSuffixes: ''
+  modernize-loop-convert.MinConfidence: reasonable
+  performance-unnecessary-value-param.AllowedTypes: ''
+  readability-uniqueptr-delete-release.PreferResetCall: 'false'
+  misc-throw-by-value-catch-by-reference.MaxSize: '64'
+  misc-definitions-in-headers.UseHeaderFileExtension: 'true'
+  google-readability-namespace-comments.SpacesBeforeComments: '2'
+  cert-err61-cpp.CheckThrowTemporaries: 'true'
+  bugprone-suspicious-missing-comma.RatioThreshold: '0.200000'
+  cppcoreguidelines-no-malloc.Allocations: '::malloc;::calloc'
+  bugprone-narrowing-conversions.IgnoreConversionFromTypes: ''
+  readability-function-size.BranchThreshold: '4294967295'
+  hicpp-use-emplace.TupleMakeFunctions: '::std::make_pair;::std::make_tuple'
+  hicpp-function-size.LineThreshold: '4294967295'
+  readability-implicit-bool-conversion.AllowIntegerConditions: 'false'
+  readability-function-size.StatementThreshold: '800'
+  hicpp-use-noexcept.ReplacementString: ''
+  readability-identifier-naming.IgnoreMainLikeFunctions: 'false'
+  cppcoreguidelines-init-variables.MathHeader: '<math.h>'
+  google-readability-function-size.StatementThreshold: '800'
+  cert-msc51-cpp.DisallowedSeedTypes: 'time_t,std::time_t'
+  bugprone-reserved-identifier.AggressiveDependentMemberLookup: 'false'
+  readability-suspicious-call-argument.DiceSimilarAbove: '70'
+  modernize-use-equals-default.IgnoreMacros: 'true'
+  readability-suspicious-call-argument.Abbreviation: 'true'
+  cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: 'false'
+  cert-dcl37-c.AggressiveDependentMemberLookup: 'false'
+  modernize-use-emplace.SmartPointers: '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  cppcoreguidelines-no-malloc.Deallocations: '::free'
+  bugprone-dangling-handle.HandleClasses: 'std::basic_string_view;std::experimental::basic_string_view'
+  misc-unused-parameters.StrictMode: 'false'
+  readability-suspicious-call-argument.JaroWinklerSimilarAbove: '85'
+  misc-const-correctness.TransformPointersAsValues: 'false'
+  readability-simplify-subscript-expr.Types: '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
+  performance-unnecessary-copy-initialization.ExcludedContainerTypes: ''
+  modernize-replace-auto-ptr.IncludeStyle: llvm
+  performance-move-const-arg.CheckTriviallyCopyableMove: 'true'
+  misc-const-correctness.TransformReferences: 'true'
+  hicpp-move-const-arg.CheckTriviallyCopyableMove: 'true'
+  readability-function-size.VariableThreshold: '4294967295'
+  readability-static-accessed-through-instance.NameSpecifierNestingThreshold: '3'
+  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
+  misc-const-correctness.AnalyzeValues: 'true'
+  readability-identifier-naming.GetConfigPerFile: 'true'
+  bugprone-narrowing-conversions.WarnOnFloatingPointNarrowingConversion: 'true'
+  cert-sig30-c.AsyncSafeFunctionSet: POSIX
+  hicpp-member-init.UseAssignment: 'false'
+  cert-err61-cpp.MaxSize: '64'
+  modernize-use-default-member-init.UseAssignment: 'false'
+  readability-simplify-boolean-expr.SimplifyDeMorgan: 'true'
+  readability-function-size.NestingThreshold: '4294967295'
+  modernize-use-override.AllowOverrideAndFinal: 'false'
+  cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes: ''
+  readability-function-size.ParameterThreshold: '4294967295'
+  hicpp-function-size.NestingThreshold: '4294967295'
+  modernize-pass-by-value.ValuesOnly: 'false'
+  readability-function-cognitive-complexity.IgnoreMacros: 'false'
+  modernize-loop-convert.IncludeStyle: llvm
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
+  bugprone-narrowing-conversions.WarnWithinTemplateInstantiation: 'false'
+  cert-err33-c.CheckedFunctions: '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  bugprone-suspicious-string-compare.WarnOnLogicalNotComparison: 'false'
+  hicpp-braces-around-statements.ShortStatementLines: '0'
+  readability-redundant-smartptr-get.IgnoreMacros: 'true'
+  cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal: 'false'
+  readability-identifier-naming.AggressiveDependentMemberLookup: 'false'
+  cert-err61-cpp.WarnOnLargeObjects: 'false'
+  misc-const-correctness.WarnPointersAsValues: 'false'
+  modernize-use-emplace.TupleTypes: '::std::pair;::std::tuple'
+  hicpp-use-emplace.IgnoreImplicitConstructors: 'false'
+  modernize-use-emplace.TupleMakeFunctions: '::std::make_pair;::std::make_tuple'
+  bugprone-narrowing-conversions.WarnOnIntegerToFloatingPointNarrowingConversion: 'true'
+  cppcoreguidelines-owning-memory.LegacyResourceProducers: '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
+  hicpp-uppercase-literal-suffix.IgnoreMacros: 'true'
+  bugprone-argument-comment.StrictMode: '0'
+  misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'false'
+  modernize-replace-random-shuffle.IncludeStyle: llvm
+  modernize-use-bool-literals.IgnoreMacros: 'true'
+  bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField: 'true'
+  google-readability-namespace-comments.ShortNamespaceLines: '10'
+  bugprone-suspicious-string-compare.StringCompareLikeFunctions: ''
+  modernize-avoid-bind.PermissiveParameterList: 'false'
+  readability-suspicious-call-argument.Suffix: 'true'
+  modernize-use-override.FinalSpelling: final
+  cert-err09-cpp.MaxSize: '64'
+  readability-suspicious-call-argument.JaroWinklerDissimilarBelow: '75'
+  hicpp-use-equals-default.IgnoreMacros: 'true'
+  modernize-use-noexcept.ReplacementString: ''
+  hicpp-use-override.OverrideSpelling: override
+  modernize-use-using.IgnoreMacros: 'true'
+  hicpp-use-override.FinalSpelling: final
+  cppcoreguidelines-explicit-virtual-functions.FinalSpelling: final
+  readability-suspicious-call-argument.MinimumIdentifierNameLength: '3'
+  bugprone-narrowing-conversions.WarnOnIntegerNarrowingConversion: 'true'
+  modernize-loop-convert.NamingStyle: CamelCase
+  cppcoreguidelines-pro-type-member-init.UseAssignment: 'false'
+  bugprone-suspicious-include.HeaderFileExtensions: ';h;hh;hpp;hxx'
+  hicpp-function-size.StatementThreshold: '800'
+  readability-suspicious-call-argument.SubstringDissimilarBelow: '40'
+  hicpp-no-malloc.Reallocations: '::realloc'
+  bugprone-stringview-nullptr.IncludeStyle: llvm
+  performance-for-range-copy.WarnOnAllAutoCopies: 'false'
+  bugprone-argument-comment.CommentIntegerLiterals: '0'
+  performance-no-automatic-move.AllowedTypes: ''
+  modernize-pass-by-value.IncludeStyle: llvm
+  bugprone-argument-comment.CommentFloatLiterals: '0'
+  bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit: '16'
+  readability-simplify-boolean-expr.ChainedConditionalReturn: 'false'
+  readability-else-after-return.WarnOnConditionVariables: 'true'
+  modernize-use-nullptr.NullMacros: 'NULL'
+  readability-suspicious-call-argument.SuffixDissimilarBelow: '25'
+  bugprone-argument-comment.CommentCharacterLiterals: '0'
+  readability-suspicious-call-argument.LevenshteinSimilarAbove: '66'
+  cppcoreguidelines-narrowing-conversions.PedanticMode: 'false'
+  modernize-make-shared.IgnoreDefaultInitialization: 'true'
+  readability-suspicious-call-argument.JaroWinkler: 'true'
+  bugprone-implicit-widening-of-multiplication-result.UseCXXHeadersInCppSources: 'true'
+  modernize-make-shared.IncludeStyle: llvm
+  readability-suspicious-call-argument.Prefix: 'true'
+  hicpp-special-member-functions.AllowMissingMoveFunctions: 'false'
+  cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions: 'false'
+  bugprone-implicit-widening-of-multiplication-result.UseCXXStaticCastsInCppSources: 'true'
+  bugprone-signed-char-misuse.CharTypdefsToIgnore: ''
+  cert-dcl51-cpp.Invert: 'false'
+  hicpp-special-member-functions.AllowSoleDefaultDtor: 'false'
+  modernize-deprecated-headers.CheckHeaderFile: 'false'
+  hicpp-use-emplace.EmplacyFunctions: 'vector::emplace_back;vector::emplace;deque::emplace;deque::emplace_front;deque::emplace_back;forward_list::emplace_after;forward_list::emplace_front;list::emplace;list::emplace_back;list::emplace_front;set::emplace;set::emplace_hint;map::emplace;map::emplace_hint;multiset::emplace;multiset::emplace_hint;multimap::emplace;multimap::emplace_hint;unordered_set::emplace;unordered_set::emplace_hint;unordered_map::emplace;unordered_map::emplace_hint;unordered_multiset::emplace;unordered_multiset::emplace_hint;unordered_multimap::emplace;unordered_multimap::emplace_hint;stack::emplace;queue::emplace;priority_queue::emplace'
+  cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors: 'true'
+  modernize-make-unique.IgnoreMacros: 'true'
+  performance-for-range-copy.AllowedTypes: ''
+  hicpp-function-size.BranchThreshold: '4294967295'
+  misc-const-correctness.AnalyzeReferences: 'true'
+  bugprone-argument-comment.CommentBoolLiterals: '0'
+  readability-braces-around-statements.ShortStatementLines: '0'
+  bugprone-argument-comment.CommentUserDefinedLiterals: '0'
+  hicpp-use-emplace.ContainersWithPushBack: '::std::vector;::std::list;::std::deque'
+  hicpp-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: 'false'
+  readability-redundant-declaration.IgnoreMacros: 'true'
+  performance-inefficient-string-concatenation.StrictMode: 'false'
+  readability-implicit-bool-conversion.AllowPointerConditions: 'false'
+  modernize-make-unique.MakeSmartPtrFunction: 'std::make_unique'
+  hicpp-function-size.ParameterThreshold: '4294967295'
+  cert-dcl51-cpp.AllowedIdentifiers: ''
+  cert-oop57-cpp.MemCpyNames: ''
+  modernize-make-unique.MakeSmartPtrFunctionHeader: '<memory>'
+  bugprone-signal-handler.AsyncSafeFunctionSet: POSIX
+  readability-suspicious-call-argument.SubstringSimilarAbove: '50'
+  cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation: 'false'
+  performance-move-const-arg.CheckMoveToConstRef: 'true'
+  modernize-use-emplace.EmplacyFunctions: 'vector::emplace_back;vector::emplace;deque::emplace;deque::emplace_front;deque::emplace_back;forward_list::emplace_after;forward_list::emplace_front;list::emplace;list::emplace_back;list::emplace_front;set::emplace;set::emplace_hint;map::emplace;map::emplace_hint;multiset::emplace;multiset::emplace_hint;multimap::emplace;multimap::emplace_hint;unordered_set::emplace;unordered_set::emplace_hint;unordered_map::emplace;unordered_map::emplace_hint;unordered_multiset::emplace;unordered_multiset::emplace_hint;unordered_multimap::emplace;unordered_multimap::emplace_hint;stack::emplace;queue::emplace;priority_queue::emplace'
+  hicpp-use-emplace.TupleTypes: '::std::pair;::std::tuple'
+  cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth: 'true'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables: 'false'
+  cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: 'false'
+  cert-oop57-cpp.MemCmpNames: ''
+  modernize-use-noexcept.UseNoexceptFalse: 'true'
+  readability-function-cognitive-complexity.Threshold: '51'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
+  readability-simplify-boolean-expr.SimplifyDeMorganRelaxed: 'false'
+  bugprone-narrowing-conversions.WarnOnEquivalentBitWidth: 'true'
+  bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: 'false'
+  performance-faster-string-find.StringLikeClasses: '::std::basic_string;::std::basic_string_view'
+  bugprone-assert-side-effect.CheckFunctionCalls: 'false'
+  cppcoreguidelines-narrowing-conversions.WarnOnIntegerToFloatingPointNarrowingConversion: 'true'
+  bugprone-string-constructor.StringNames: '::std::basic_string;::std::basic_string_view'
+  bugprone-assert-side-effect.AssertMacros: assert
+  bugprone-exception-escape.IgnoredExceptions: ''
+  bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons: 'true'
+  modernize-use-default-member-init.IgnoreMacros: 'true'
+  llvm-qualified-auto.AddConstToQualified: 'false'
+  bugprone-argument-comment.IgnoreSingleArgument: '0'
+  cert-str34-c.CharTypdefsToIgnore: ''
+  llvm-else-after-return.WarnOnConditionVariables: 'false'
+  bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant: 'true'
+  modernize-raw-string-literal.DelimiterStem: lit
+  readability-suspicious-call-argument.Dice: 'true'
+  misc-throw-by-value-catch-by-reference.WarnOnLargeObjects: 'false'
+  cert-dcl37-c.Invert: 'false'
+  modernize-raw-string-literal.ReplaceShorterLiterals: 'false'
+  performance-inefficient-vector-operation.VectorLikeClasses: '::std::vector'
+  modernize-use-auto.RemoveStars: 'false'
+  bugprone-implicit-widening-of-multiplication-result.IncludeStyle: llvm
+  readability-redundant-member-init.IgnoreBaseInCopyConstructors: 'false'
+  performance-unnecessary-value-param.IncludeStyle: llvm
+  modernize-replace-disallow-copy-and-assign-macro.MacroName: DISALLOW_COPY_AND_ASSIGN
+  hicpp-use-nullptr.NullMacros: ''
+  llvm-else-after-return.WarnOnUnfixable: 'false'
+  cert-msc32-c.DisallowedSeedTypes: 'time_t,std::time_t'
 ...
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Programming
 
 The source code is mixed C and C++.
 
-This application is to be used with `Espressif IoT Development Framework`_ (ESP-IDF). It is tested with version v4.4.2 (rev 1b16ef6cfc2479a08136782f9dc57effefa86f66)
+This application is to be used with `Espressif IoT Development Framework`_ (ESP-IDF). It is tested with version v5.0-beta1-720-gda9a78ebfc (rev da9a78ebfc45e4158f87811908337fa1d40912f3)
 
 Please check ESP-IDF docs for getting started instructions.
 

--- a/ci/build_for_pc.sh
+++ b/ci/build_for_pc.sh
@@ -11,6 +11,6 @@ ninja
 cd ..
 mkdir build_clang
 cd build_clang
-CC=clang-12 CXX=clang++-12 cmake ../native -G Ninja -D CMAKE_CXX_FLAGS=-DASIO_STANDALONE
+CC=clang-15 CXX=clang++-15 cmake ../native -G Ninja -D CMAKE_CXX_FLAGS=-DASIO_STANDALONE
 ninja
 cd ..

--- a/ci/check_codestyle.sh
+++ b/ci/check_codestyle.sh
@@ -4,4 +4,4 @@
 
 set -eo pipefail
 
-ci/run-clang-format.py --clang-format-executable clang-format-12 -r main/ components/ native/
+ci/run-clang-format.py --clang-format-executable clang-format-15 -r main/ components/ native/

--- a/ci/static_code_analysis.sh
+++ b/ci/static_code_analysis.sh
@@ -6,6 +6,6 @@ set -eo pipefail
 
 mkdir build_clang
 cd build_clang
-CC=clang-12 CXX=clang++-12 cmake ../native -G Ninja -D CMAKE_CXX_FLAGS=-DASIO_STANDALONE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+CC=clang-15 CXX=clang++-15 cmake ../native -G Ninja -D CMAKE_CXX_FLAGS=-DASIO_STANDALONE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-run-clang-tidy-12.py -clang-tidy-binary clang-tidy-12
+run-clang-tidy-15.py -clang-tidy-binary clang-tidy-15

--- a/components/sip_client/CMakeLists.txt
+++ b/components/sip_client/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
                       INCLUDE_DIRS include
-                      REQUIRES asio)
+                      )
 

--- a/components/sip_client/idf_component.yml
+++ b/components/sip_client/idf_component.yml
@@ -1,0 +1,19 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/asio:
+    version: "^1.14.1~3"
+    public: true
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/components/sip_client/include/sip_client/asio_udp_client.h
+++ b/components/sip_client/include/sip_client/asio_udp_client.h
@@ -139,7 +139,7 @@ public:
 
         ESP_LOGI(TAG, "Doing DNS lookup for host=%s port=%s", m_server_ip.c_str(), m_server_port.c_str());
         asio::ip::udp::resolver resolver(m_io_context);
-        asio::ip::udp::resolver::results_type endpoints = resolver.resolve(asio::ip::udp::v4(), m_server_ip, m_server_port, ec);
+        const asio::ip::udp::resolver::results_type endpoints = resolver.resolve(asio::ip::udp::v4(), m_server_ip, m_server_port, ec);
 
         if (endpoints.empty() || ec)
         {
@@ -207,10 +207,10 @@ public:
     {
         ESP_LOGV(TAG, "Sending %d byte", m_tx_buffer.size());
         ESP_LOGV(TAG, "Sending following data: %s", m_tx_buffer.data());
-        asio::socket_base::message_flags flags = 0;
+        const asio::socket_base::message_flags flags = 0;
         asio::error_code ec;
 
-        size_t result = m_socket.send_to(
+        const size_t result = m_socket.send_to(
             asio::buffer(m_tx_buffer.data(), m_tx_buffer.size()), m_destination_endpoint, flags, ec);
 
         if (ec || (result <= 0))

--- a/components/sip_client/include/sip_client/mbedtls_md5.h
+++ b/components/sip_client/include/sip_client/mbedtls_md5.h
@@ -46,9 +46,9 @@ public:
         mbedtls_md5_update(&m_ctx, reinterpret_cast<const unsigned char*>(input.c_str()), input.size());
     }
 
-    void finish(unsigned char hash[16])
+    void finish(std::array<unsigned char, 16>& hash)
     {
-        mbedtls_md5_finish(&m_ctx, hash);
+        mbedtls_md5_finish(&m_ctx, hash.data());
     }
 
 private:

--- a/components/sip_client/include/sip_client/mbedtls_md5.h
+++ b/components/sip_client/include/sip_client/mbedtls_md5.h
@@ -38,17 +38,17 @@ public:
 
     void start()
     {
-        mbedtls_md5_starts_ret(&m_ctx);
+        mbedtls_md5_starts(&m_ctx);
     }
 
     void update(const std::string& input)
     {
-        mbedtls_md5_update_ret(&m_ctx, reinterpret_cast<const unsigned char*>(input.c_str()), input.size());
+        mbedtls_md5_update(&m_ctx, reinterpret_cast<const unsigned char*>(input.c_str()), input.size());
     }
 
     void finish(unsigned char hash[16])
     {
-        mbedtls_md5_finish_ret(&m_ctx, hash);
+        mbedtls_md5_finish(&m_ctx, hash);
     }
 
 private:

--- a/components/sip_client/include/sip_client/sip_client.h
+++ b/components/sip_client/include/sip_client/sip_client.h
@@ -38,7 +38,6 @@ public:
         : m_sip {
             io_context, user, pwd, server_ip, server_port, my_ip, m_sm, *this
         }
-        , m_logger {}
         , m_sm { m_sip, m_logger }
     {
     }
@@ -96,6 +95,6 @@ public:
 
 private:
     SipClientInternal m_sip;
-    Logger m_logger;
+    Logger m_logger {};
     SmlSmT m_sm;
 };

--- a/components/sip_client/include/sip_client/sip_client_internal.h
+++ b/components/sip_client/include/sip_client/sip_client_internal.h
@@ -66,7 +66,7 @@ public:
         bool result_rtp = m_rtp_socket.init();
         bool result_sip = m_socket.init();
 
-        //TODO: remove this here, do it properly with boost::sml
+        // TODO: remove this here, do it properly with boost::sml
         if (result_rtp && result_sip)
         {
             asio::dispatch(m_io_context, [this]() {
@@ -137,10 +137,10 @@ public:
         m_rtp_socket.deinit();
     }
 
-    //send initial register request
+    // send initial register request
     void register_unauth()
     {
-        //sending REGISTER without auth
+        // sending REGISTER without auth
         m_tag = std::rand() % 2147483647;
         m_branch = std::rand() % 2147483647;
         send_sip_register();
@@ -148,11 +148,11 @@ public:
         m_branch = std::rand() % 2147483647;
     }
 
-    //send  register request
+    // send  register request
     void register_auth()
     {
         m_sip_sequence_number++;
-        //sending REGISTER with auth
+        // sending REGISTER with auth
         compute_auth_response("REGISTER", "sip:" + m_server_ip);
         send_sip_register();
     }
@@ -187,7 +187,7 @@ public:
 
     void send_invite(const ev_401_unauthorized& /*unused*/)
     {
-        //first ack the prev sip 401/407 packet
+        // first ack the prev sip 401/407 packet
         send_sip_ack();
 
         m_sdp_session_id = static_cast<uint32_t>(std::rand());
@@ -222,14 +222,14 @@ public:
         ESP_LOGD(TAG, "Sending cancel request");
         send_sip_cancel();
 
-        //TODO: if call in progress, send bye
-        //ESP_LOGD(TAG, "Sending bye request");
-        //send_sip_bye();
+        // TODO: if call in progress, send bye
+        // ESP_LOGD(TAG, "Sending bye request");
+        // send_sip_bye();
     }
 
     void handle_invite(const ev_rx_invite& /*unused*/)
     {
-        //received an invite, answered it already with ok, so new call is established, because someone called us
+        // received an invite, answered it already with ok, so new call is established, because someone called us
         if (m_event_handler)
         {
             m_event_handler(m_sip_client, SipClientEvent { SipClientEvent::Event::CALL_START });
@@ -238,7 +238,7 @@ public:
 
     void call_established()
     {
-        //ack to ok after invite
+        // ack to ok after invite
         send_sip_ack();
         if (m_event_handler)
         {
@@ -516,23 +516,23 @@ private:
         {
             send_sip_header("ACK", m_uri, m_to_uri, tx_buffer);
         }
-        //std::string m_sdp_session_o;
-        //std::string m_sdp_session_s;
-        //std::string m_sdp_session_c;
-        //m_tx_sdp_buffer.clear();
-        //TODO: populate sdp body
-        //m_tx_sdp_buffer << "v=0\r\n"
+        // std::string m_sdp_session_o;
+        // std::string m_sdp_session_s;
+        // std::string m_sdp_session_c;
+        // m_tx_sdp_buffer.clear();
+        // TODO: populate sdp body
+        // m_tx_sdp_buffer << "v=0\r\n"
         //	              << m_sdp_session_o << "\r\n"
         //	      << m_sdp_session_s << "\r\n"
         //	      << m_sdp_session_c << "\r\n"
         //	      << "t=0 0\r\n";
-        //TODO: copy each m line and select appropriate a line
-        //tx_buffer << "Content-Type: application/sdp\r\n";
-        //tx_buffer << "Content-Length: " << m_tx_sdp_buffer.size() << "\r\n";
-        //tx_buffer << "Allow-Events: telephone-event\r\n";
+        // TODO: copy each m line and select appropriate a line
+        // tx_buffer << "Content-Type: application/sdp\r\n";
+        // tx_buffer << "Content-Length: " << m_tx_sdp_buffer.size() << "\r\n";
+        // tx_buffer << "Allow-Events: telephone-event\r\n";
         tx_buffer << "Content-Length: 0\r\n";
         tx_buffer << "\r\n";
-        //tx_buffer << m_tx_sdp_buffer.data();
+        // tx_buffer << m_tx_sdp_buffer.data();
 
         m_socket.send_buffered_data();
     }
@@ -717,7 +717,7 @@ private:
     uint32_t m_sip_sequence_number;
     uint32_t m_call_id;
 
-    //auth stuff
+    // auth stuff
     std::string m_response;
     std::string m_realm;
     std::string m_nonce;
@@ -726,7 +726,7 @@ private:
     uint32_t m_tag;
     uint32_t m_branch;
 
-    //misc stuff
+    // misc stuff
     std::string m_caller_display;
 
     uint32_t m_sdp_session_id;

--- a/components/sip_client/include/sip_client/sip_client_internal.h
+++ b/components/sip_client/include/sip_client/sip_client_internal.h
@@ -63,8 +63,8 @@ public:
 
     bool init()
     {
-        bool result_rtp = m_rtp_socket.init();
-        bool result_sip = m_socket.init();
+        const bool result_rtp = m_rtp_socket.init();
+        const bool result_sip = m_socket.init();
 
         // TODO: remove this here, do it properly with boost::sml
         if (result_rtp && result_sip)
@@ -317,7 +317,7 @@ private:
 
         m_command_timeout_timer.cancel();
 
-        SipPacket::Status reply = packet.get_status();
+        const SipPacket::Status reply = packet.get_status();
         ESP_LOGI(TAG, "Parsing the packet ok, reply code=%d", static_cast<int>(packet.get_status()));
 
         if (reply == SipPacket::Status::SERVER_ERROR_500)
@@ -417,7 +417,7 @@ private:
     void send_sip_register()
     {
         TxBufferT& tx_buffer = m_socket.get_new_tx_buf();
-        std::string uri = "sip:" + m_server_ip;
+        const std::string uri = "sip:" + m_server_ip;
 
         send_sip_header("REGISTER", uri, "sip:" + m_user + "@" + m_server_ip, tx_buffer);
 
@@ -634,14 +634,14 @@ private:
 
     bool read_param(const std::string& line, const std::string& param_name, std::string& output)
     {
-        std::string param(param_name + "=\"");
+        const std::string param(param_name + "=\"");
         size_t pos = line.find(param);
         if (pos == std::string::npos)
         {
             return false;
         }
         pos += param.size();
-        size_t pos_end = line.find('\"', pos);
+        const size_t pos_end = line.find('\"', pos);
         if (pos_end == std::string::npos)
         {
             return false;

--- a/components/sip_client/include/sip_client/sip_client_internal.h
+++ b/components/sip_client/include/sip_client/sip_client_internal.h
@@ -47,11 +47,9 @@ public:
         , m_to_uri("sip:" + user + "@" + server_ip)
         , m_sip_sequence_number(std::rand() % 2147483647)
         , m_call_id(std::rand() % 2147483647)
-        , m_proxy_auth(false)
         , m_tag(std::rand() % 2147483647)
         , m_branch(std::rand() % 2147483647)
         , m_caller_display(m_user)
-        , m_sdp_session_id(0)
         , m_sm(sm)
         , m_io_context(io_context)
         , m_timer(io_context)
@@ -721,7 +719,7 @@ private:
     std::string m_response;
     std::string m_realm;
     std::string m_nonce;
-    bool m_proxy_auth;
+    bool m_proxy_auth { false };
 
     uint32_t m_tag;
     uint32_t m_branch;
@@ -729,7 +727,7 @@ private:
     // misc stuff
     std::string m_caller_display;
 
-    uint32_t m_sdp_session_id;
+    uint32_t m_sdp_session_id { 0 };
     Buffer<1024> m_tx_sdp_buffer;
 
     std::function<void(SipClientT&, const SipClientEvent&)> m_event_handler;

--- a/components/sip_client/include/sip_client/sip_client_internal.h
+++ b/components/sip_client/include/sip_client/sip_client_internal.h
@@ -652,7 +652,7 @@ private:
     {
         std::string ha1_text;
         std::string ha2_text;
-        unsigned char hash[16];
+        std::array<unsigned char, 16> hash {};
 
         m_response = "";
         std::string data = m_user + ":" + m_realm + ":" + m_pwd;
@@ -660,7 +660,7 @@ private:
         m_md5.start();
         m_md5.update(data);
         m_md5.finish(hash);
-        to_hex(ha1_text, hash, 16);
+        to_hex(ha1_text, hash);
         ESP_LOGV(TAG, "Calculating md5 for : %s", data.c_str());
         ESP_LOGV(TAG, "Hex ha1 is %s", ha1_text.c_str());
 
@@ -669,7 +669,7 @@ private:
         m_md5.start();
         m_md5.update(data);
         m_md5.finish(hash);
-        to_hex(ha2_text, hash, 16);
+        to_hex(ha2_text, hash);
         ESP_LOGV(TAG, "Calculating md5 for : %s", data.c_str());
         ESP_LOGV(TAG, "Hex ha2 is %s", ha2_text.c_str());
 
@@ -678,21 +678,21 @@ private:
         m_md5.start();
         m_md5.update(data);
         m_md5.finish(hash);
-        to_hex(m_response, hash, 16);
+        to_hex(m_response, hash);
         ESP_LOGV(TAG, "Calculating md5 for : %s", data.c_str());
         ESP_LOGV(TAG, "Hex response is %s", m_response.c_str());
     }
 
-    void to_hex(std::string& dest, const unsigned char* data, uint8_t len)
+    void to_hex(std::string& dest, const std::array<unsigned char, 16>& data)
     {
-        static const char hexits[17] = "0123456789abcdef";
+        static const std::array<char, 16> hexits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
         dest = "";
-        dest.reserve(len * 2 + 1);
-        for (int i = 0; i < len; i++)
+        dest.reserve(data.size() * 2 + 1);
+        for (auto byte : data)
         {
-            dest.push_back(hexits[data[i] >> 4]);
-            dest.push_back(hexits[data[i] & 0x0F]);
+            dest.push_back(hexits[byte >> 4]);
+            dest.push_back(hexits[byte & 0x0F]);
         }
     }
 

--- a/components/sip_client/include/sip_client/sip_packet.h
+++ b/components/sip_client/include/sip_client/sip_packet.h
@@ -58,10 +58,6 @@ public:
     SipPacket(char* input_buffer, size_t input_buffer_length)
         : m_buffer(input_buffer)
         , m_buffer_length(input_buffer_length)
-        , m_status(Status::UNKNOWN)
-        , m_method(Method::UNKNOWN)
-        , m_content_type(ContentType::UNKNOWN)
-        , m_content_length(0)
     {
     }
 
@@ -526,10 +522,10 @@ private:
     char* m_buffer;
     const size_t m_buffer_length;
 
-    Status m_status;
-    Method m_method;
-    ContentType m_content_type;
-    uint32_t m_content_length;
+    Status m_status { Status::UNKNOWN };
+    Method m_method { Method::UNKNOWN };
+    ContentType m_content_type { ContentType::UNKNOWN };
+    uint32_t m_content_length { 0 };
 
     std::string m_realm;
     std::string m_nonce;

--- a/components/sip_client/include/sip_client/sip_packet.h
+++ b/components/sip_client/include/sip_client/sip_packet.h
@@ -208,7 +208,7 @@ private:
         do
         {
             auto length = static_cast<size_t>(end_position - start_position);
-            if (length == 0) //line only contains the line ending
+            if (length == 0) // line only contains the line ending
             {
                 ESP_LOGV(TAG, "Valid end of header detected");
                 if (end_position + LINE_ENDING_LEN >= m_buffer + m_buffer_length)
@@ -225,8 +225,8 @@ private:
             char* next_start_position = end_position + LINE_ENDING_LEN;
             line_number++;
 
-            //create a proper null terminated c string
-            //from here on string functions may be used!
+            // create a proper null terminated c string
+            // from here on string functions may be used!
             memset(end_position, 0, LINE_ENDING_LEN);
             ESP_LOGV(TAG, "Parsing line: %s", start_position);
 
@@ -240,7 +240,7 @@ private:
                 || (strncmp(PROXY_AUTHENTICATE, start_position, strlen(PROXY_AUTHENTICATE)) == 0))
             {
                 ESP_LOGV(TAG, "Detect authenticate line");
-                //read realm and nonce from authentication line
+                // read realm and nonce from authentication line
                 if (!read_param(start_position, REALM, m_realm))
                 {
                     ESP_LOGW(TAG, "Failed to read realm in authenticate line");
@@ -339,16 +339,16 @@ private:
 
             else if (line_number == 1)
             {
-                //first line, but no response
+                // first line, but no response
                 m_method = convert_method(start_position);
             }
 
-            //go to next line
+            // go to next line
             start_position = next_start_position;
             end_position = strstr(start_position, LINE_ENDING);
         } while (end_position != nullptr);
 
-        //no line only containing the line ending found :(
+        // no line only containing the line ending found :(
         return false;
     }
 
@@ -371,15 +371,15 @@ private:
         do
         {
             auto length = static_cast<size_t>(end_position - start_position);
-            if (length == 0) //line only contains the line ending
+            if (length == 0) // line only contains the line ending
             {
                 return true;
             }
 
             char* next_start_position = end_position + LINE_ENDING_LEN;
 
-            //create a proper null terminated c string
-            //from here on string functions may be used!
+            // create a proper null terminated c string
+            // from here on string functions may be used!
             memset(end_position, 0, LINE_ENDING_LEN);
             ESP_LOGV(TAG, "Parsing line: %s", start_position);
 
@@ -408,7 +408,7 @@ private:
                 m_cip = std::string(start_position + strlen(CIP));
             }
 
-            //go to next line
+            // go to next line
             start_position = next_start_position;
             end_position = strstr(start_position, LINE_ENDING);
         } while (end_position != nullptr);

--- a/components/sip_client/include/sip_client/sip_packet.h
+++ b/components/sip_client/include/sip_client/sip_packet.h
@@ -67,7 +67,7 @@ public:
 
     bool parse()
     {
-        bool result = parse_header();
+        const bool result = parse_header();
         if (!result)
         {
             return false;
@@ -232,7 +232,7 @@ private:
 
             if (strstr(start_position, SIP_2_0_SPACE) == start_position)
             {
-                long code = strtol(start_position + strlen(SIP_2_0_SPACE), nullptr, 10);
+                const long code = strtol(start_position + strlen(SIP_2_0_SPACE), nullptr, 10);
                 ESP_LOGV(TAG, "Detect status %ld", code);
                 m_status = convert_status(code);
             }
@@ -274,7 +274,7 @@ private:
                     const char* expires_pos = strstr(close_pos + 1, ";expires=");
                     if (expires_pos != nullptr)
                     {
-                        long contact_expires = strtol(expires_pos + strlen(";expires="), nullptr, 10);
+                        const long contact_expires = strtol(expires_pos + strlen(";expires="), nullptr, 10);
                         if (contact_expires < 0)
                         {
                             ESP_LOGW(TAG, "Invalid contact expires %ld", contact_expires);
@@ -326,7 +326,7 @@ private:
             }
             else if (strstr(start_position, CONTENT_LENGTH) == start_position)
             {
-                long content_length = strtol(start_position + strlen(CONTENT_LENGTH), nullptr, 10);
+                const long content_length = strtol(start_position + strlen(CONTENT_LENGTH), nullptr, 10);
                 if (content_length < 0)
                 {
                     ESP_LOGW(TAG, "Invalid content length %ld", content_length);
@@ -389,7 +389,7 @@ private:
             }
             else if (strstr(start_position, DURATION) == start_position)
             {
-                long duration = strtol(start_position + strlen(DURATION), nullptr, 10);
+                const long duration = strtol(start_position + strlen(DURATION), nullptr, 10);
                 if (duration < 0)
                 {
                     ESP_LOGW(TAG, "Invalid duration %ld", duration);

--- a/components/sip_client/include/sip_client/sip_packet.h
+++ b/components/sip_client/include/sip_client/sip_packet.h
@@ -268,9 +268,9 @@ private:
                     m_contact = std::string(open_pos + 1, close_pos);
 
                     /* in the SIP 200 OK finishing a successful REGISTER, the contact line might also
-		     * contain the expire information from the server, e.g.
-		     * Contact: <...>;expires=300
-		     */
+                     * contain the expire information from the server, e.g.
+                     * Contact: <...>;expires=300
+                     */
                     const char* expires_pos = strstr(close_pos + 1, ";expires=");
                     if (expires_pos != nullptr)
                     {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:release-v4.4
+FROM espressif/idf:release-v5.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -21,14 +21,14 @@ apt-get update \
 
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-echo deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-12 main > /etc/apt/sources.list.d/llvm.list
+echo deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-15 main > /etc/apt/sources.list.d/llvm.list
 
 wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-2.tar.gz -O /tmp/asio-1-12-2.tar.gz
 
 tar -C /usr/include --strip-components=3 -x -f /tmp/asio-1-12-2.tar.gz asio-asio-1-12-2/asio/include/
 
 apt-get update \
-    && apt-get install -y clang-12 \
-	       clang-format-12 \
-	       clang-tidy-12 \
+    && apt-get install -y clang-15 \
+	       clang-format-15 \
+	       clang-tidy-15 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -11,7 +11,8 @@ apt-get update \
 	       gnupg \
 	       software-properties-common \
 	       wget \
-	       libmbedtls-dev
+	       libmbedtls-dev \
+	       g++
 
 # wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
 # apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'

--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -23,9 +23,9 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 echo deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-15 main > /etc/apt/sources.list.d/llvm.list
 
-wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-2.tar.gz -O /tmp/asio-1-12-2.tar.gz
+wget https://github.com/chriskohlhoff/asio/archive/asio-1-14-1.tar.gz -O /tmp/asio-1-14-1.tar.gz
 
-tar -C /usr/include --strip-components=3 -x -f /tmp/asio-1-12-2.tar.gz asio-asio-1-12-2/asio/include/
+tar -C /usr/include --strip-components=3 -x -f /tmp/asio-1-14-1.tar.gz asio-asio-1-14-1/asio/include/
 
 apt-get update \
     && apt-get install -y clang-15 \

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(SRCS ./main.cpp
-                       REQUIRES nvs_flash sip_client)
+                       REQUIRES driver esp_netif esp_wifi mbedtls
+		                nvs_flash sip_client)
 
 #INCLUDE_DIRS include                       # Edit following two lines to set component requirements (see docs)
 #                       REQUIRES )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/asio: "^1.14.1~3"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -79,7 +79,7 @@ static std::string get_gw_ip_address(const system_event_sta_got_ip_t* got_ip)
     const ip4_addr_t* gateway = &got_ip->ip_info.gw;
     return ip_to_string(gateway);
 }
-#endif //CONFIG_SIP_SERVER_IS_DHCP_SERVER
+#endif // CONFIG_SIP_SERVER_IS_DHCP_SERVER
 
 static std::string get_local_ip_address(const esp_ip4_addr_t* got_ip)
 {
@@ -136,7 +136,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         esp_ip4_addr_t* got_ip = &event->ip_info.ip;
 #ifdef CONFIG_SIP_SERVER_IS_DHCP_SERVER
         ctx->client->set_server_ip(get_gw_ip_address(got_ip));
-#endif //CONFIG_SIP_SERVER_IS_DHCP_SERVER
+#endif // CONFIG_SIP_SERVER_IS_DHCP_SERVER
         ctx->client->set_my_ip(get_local_ip_address(got_ip));
         xEventGroupSetBits(wifi_event_group, CONNECTED_BIT);
     }
@@ -253,6 +253,6 @@ extern "C" void app_main(void)
     // because some c++ objects are not fully initialized
     xTaskCreatePinnedToCore(&sip_task, "sip_task", 8192, &handlers, 5, NULL, 0);
 
-    //blocks forever
+    // blocks forever
     button_input_handler.run();
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -159,8 +159,9 @@ static void initialize_wifi()
     strncpy((char*)wifi_config.sta.password, CONFIG_WIFI_PASSWORD, sizeof(wifi_config.sta.password));
 
     /* Setting a password implies station will connect to all security modes including WEP/WPA.
-      * However these modes are deprecated and not advisable to be used. Incase your Access point
-      * doesn't support WPA2, these mode can be enabled by commenting below line */
+     * However these modes are deprecated and not advisable to be used. Incase your Access point
+     * doesn't support WPA2, these mode can be enabled by commenting below line.
+     */
     wifi_config.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
 
     wifi_config.sta.pmf_cfg.capable = true;

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -33,11 +33,11 @@ add_executable(sip-client ${SOURCES})
 target_link_libraries(sip-client mbedcrypto ${CMAKE_THREAD_LIBS_INIT})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ${PEDANTIC_WARNINGS})
-  target_compile_options(sip-client PRIVATE -Wall -Wextra -Weverything -Wno-c++98-compat -Wno-format-nonliteral -Wno-gnu-zero-variadic-macro-arguments -Wno-c++98-compat-pedantic)
+  target_compile_options(sip-client PRIVATE -Wall -Wextra -Weverything -Wno-c++98-compat -Wno-format-nonliteral -Wno-gnu-zero-variadic-macro-arguments -Wno-c++98-compat-pedantic -Wno-deprecated-declarations)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${PEDANTIC_WARNINGS})
-  target_compile_options(sip-client PRIVATE -Wall -Wextra -Wno-c++98-compat -Wno-format-nonliteral -Wno-gnu-zero-variadic-macro-arguments -Wno-c++98-compat-pedantic -pedantic)
+  target_compile_options(sip-client PRIVATE -Wall -Wextra -Wno-c++98-compat -Wno-format-nonliteral -Wno-gnu-zero-variadic-macro-arguments -Wno-c++98-compat-pedantic -Wno-deprecated-declarations -pedantic)
 else()
-  target_compile_options(sip-client PRIVATE -Wall -Wextra -Werror)
+  target_compile_options(sip-client PRIVATE -Wall -Wextra -Werror -Wno-deprecated-declarations)
 endif()
 
 # set the C++ standard

--- a/native/keyboard_input.h
+++ b/native/keyboard_input.h
@@ -19,7 +19,7 @@
 class KeyboardInput
 {
 public:
-    KeyboardInput(asio::io_context& io_context)
+    explicit KeyboardInput(asio::io_context& io_context)
         : stream { io_context, ::dup(STDIN_FILENO) }
     {
         termios current {};

--- a/native/keyboard_input.h
+++ b/native/keyboard_input.h
@@ -34,7 +34,7 @@ public:
         tcsetattr(0, TCSANOW, &old_termios);
     }
 
-    void do_read(std::function<void(char c)> on_press)
+    void do_read(const std::function<void(char c)>& on_press)
     {
         asio::async_read(
             stream, asio::buffer(buf),

--- a/native/keyboard_input.h
+++ b/native/keyboard_input.h
@@ -22,7 +22,7 @@ public:
     KeyboardInput(asio::io_context& io_context)
         : stream { io_context, ::dup(STDIN_FILENO) }
     {
-        struct termios current;
+        termios current {};
         tcgetattr(0, &old_termios);
         current = old_termios;
         current.c_lflag &= ~ICANON; /* disable buffered i/o */
@@ -56,8 +56,8 @@ public:
 
 private:
     asio::posix::stream_descriptor stream;
-    std::array<char, 1> buf;
-    struct termios old_termios;
+    std::array<char, 1> buf {};
+    termios old_termios {};
 
     static constexpr char const* TAG = "key";
 };

--- a/native/main.cpp
+++ b/native/main.cpp
@@ -61,7 +61,7 @@ void sip_task(void* pvParameters)
     {
         if (!client.is_initialized())
         {
-            bool result = client.init();
+            const bool result = client.init();
             ESP_LOGI(TAG, "SIP client initialized %ssuccessfully", result ? "" : "un");
             if (!result)
             {

--- a/native/main.cpp
+++ b/native/main.cpp
@@ -66,7 +66,7 @@ void sip_task(void* pvParameters)
             if (!result)
             {
                 ESP_LOGI(TAG, "Waiting to try again...");
-                sleep(2); //sleep two seconds
+                sleep(2); // sleep two seconds
                 continue;
             }
             client.set_event_handler([](SipClientT& client, const SipClientEvent& event) {


### PR DESCRIPTION
This pr adapts the code for esp-idf 5.0 (pre-release version). For this the asio lib version used by the pc is updated in the docker image and clang is upgraded from 12 to 15.
