### PR TITLE
Add new Kconfig symbol to disable http server

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -118,4 +118,10 @@ config CALLER_DISPLAY_MESSAGE
 
                 See README.md for details.
 
+config HTTP_SERVER
+       bool "Include HTTP server"
+       default y
+       help
+         This enables/disables the inclusion of the http server.
+
 endmenu


### PR DESCRIPTION
It is not possible to remove the web_Server component from idf_component_register if main, see
https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32/api-guides/build-system.html#component-requirements

Setting CONFIG_HTTP_SERVER to n reduces the flash usage by about 64kByte.