### PR TITLE
Add mdns service and set hostname in DHCP requests

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -118,6 +118,12 @@ config CALLER_DISPLAY_MESSAGE
 
                 See README.md for details.
 
+config HOSTNAME
+       string "Hostname"
+       default "sip-call"
+       help
+         The hostname that is advertised via DHCP and (if enabled) mDNS.
+
 config HTTP_SERVER
        bool "Include HTTP server"
        default y
@@ -130,14 +136,6 @@ config MDNS_SERVER
        default y if HTTP_SERVER
        help
          This enables mDNS server on the ESP32
-
-config MDNS_HOSTNAME
-       string "Own hostname for mDNS"
-       depends on MDNS_SERVER
-       default "sip-call"
-       help
-         The hostname that is advertised via mDNS. The esp32 is reachable
-	 from the browser via http://sip-call.local.
 
 config MDNS_INSTANCE
        string "Instance name for mDNS"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -125,4 +125,25 @@ config HTTP_SERVER
        help
          This enables/disables the inclusion of the http server.
 
+config MDNS_SERVER
+       bool "Provide own hostname via mDNS"
+       default y if HTTP_SERVER
+       help
+         This enables mDNS server on the ESP32
+
+config MDNS_HOSTNAME
+       string "Own hostname for mDNS"
+       depends on MDNS_SERVER
+       default "sip-call"
+       help
+         The hostname that is advertised via mDNS. The esp32 is reachable
+	 from the browser via http://sip-call.local.
+
+config MDNS_INSTANCE
+       string "Instance name for mDNS"
+       depends on MDNS_SERVER
+       default "ESP32 SIP Call"
+       help
+         The instance name used for mDNS.
+
 endmenu

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,7 @@
 ## IDF Component Manager Manifest File
 dependencies:
   espressif/asio: "^1.14.1~3"
+  espressif/mdns: "^1.0.7"
   ## Required IDF version
   idf:
     version: ">=4.1.0"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -164,7 +164,8 @@ static void initialize_wifi()
 
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
-    esp_netif_create_default_wifi_sta();
+    esp_netif_t* sta_netif = esp_netif_create_default_wifi_sta();
+    ESP_ERROR_CHECK(esp_netif_set_hostname(sta_netif, CONFIG_HOSTNAME));
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
@@ -263,7 +264,7 @@ extern "C" void app_main(void)
 
 #ifdef CONFIG_MDNS_SERVER
     ESP_ERROR_CHECK(mdns_init());
-    ESP_ERROR_CHECK(mdns_hostname_set(CONFIG_MDNS_HOSTNAME));
+    ESP_ERROR_CHECK(mdns_hostname_set(CONFIG_HOSTNAME));
     ESP_ERROR_CHECK(mdns_instance_name_set(CONFIG_MDNS_INSTANCE));
 
 #ifdef CONFIG_HTTP_SERVER

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -37,6 +37,10 @@
 #include "web_server/web_server.h"
 #endif /* CONFIG_HTTP_SERVER */
 
+#ifdef CONFIG_MDNS_SERVER
+#include "mdns.h"
+#endif /* CONFIG_MDNS_SERVER */
+
 #include <string.h>
 
 static constexpr auto BELL_GPIO_PIN = static_cast<gpio_num_t>(CONFIG_BELL_INPUT_GPIO);
@@ -256,6 +260,20 @@ extern "C" void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     initialize_wifi();
+
+#ifdef CONFIG_MDNS_SERVER
+    ESP_ERROR_CHECK(mdns_init());
+    ESP_ERROR_CHECK(mdns_hostname_set(CONFIG_MDNS_HOSTNAME));
+    ESP_ERROR_CHECK(mdns_instance_name_set(CONFIG_MDNS_INSTANCE));
+
+#ifdef CONFIG_HTTP_SERVER
+    mdns_txt_item_t serviceTxtData[3] = {
+        { "board", "esp32" },
+    };
+    ESP_ERROR_CHECK(mdns_service_add("SIP-Call-WebServer", "_http", "_tcp", 80, serviceTxtData, 1));
+#endif /* CONFIG_HTTP_SERVER */
+
+#endif /* CONFIG_MDNS_SERVER */
 
     asio::io_context io_context { 1 };
 


### PR DESCRIPTION
The esp32 is reachable from the browser via http://sip-call.local (if the os supports mdns).

This uses about 24kByte additional flash.