### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Code formatting
 +++++++++++++++
 
 Clang-format is used to format the code. The settings are stored in .clangformat. The format of external files, e.g.
-components/sip_client/include/boost/sml.hpp should not be changed. To run clang-format (e.g. version 12) over all files::
+components/sip_client/include/boost/sml.hpp (`boost-ext/sml`_) should not be changed. To run clang-format (e.g. version 12) over all files::
 
   find . -regex '.*\.\(cpp\|cc\|cxx\|h\)' -exec clang-format -style=file -i {} \;
 
@@ -100,3 +100,4 @@ On the AVM Fritzbox the number \*\*9 can be used to let all connected phones rin
 
 .. _`Espressif IoT Development Framework`: https://esp-idf.readthedocs.io/
 .. _`Selecting soc build target`: https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32/api-guides/tools/idf-py.html#select-the-target-chip-set-target
+.. _`boost-ext/sml`: https://github.com/boost-ext/sml


### PR DESCRIPTION
Hello **sip_call** community!

I'm collecting a list of projects that use state machines.
If we can see in the documentation that **sip_call** uses the `boost-ext/sml` library then it will be easier for people to find and meet.

I found project **sip_call** by accident due to commit [cdd5667](https://github.com/chrta/sip_call/commit/cdd56676e163a56c6120cd3c99aef502d9edd927)
And if it can be found in the readme markup, it might be better for a developer working on state machines. To see usage.

Regards