### PR TITLE
Drop telephone-event from SDP offer to force DTMF via SIP INFO

### DIFF
--- a/components/sip_client/include/sip_client/sip_client_internal.h
+++ b/components/sip_client/include/sip_client/sip_client_internal.h
@@ -464,11 +464,9 @@ private:
                         << "s=sip-client/0.0.1\r\n"
                         << "c=IN IP4 " << m_my_ip << "\r\n"
                         << "t=0 0\r\n"
-                        << "m=audio " << LOCAL_RTP_PORT << " RTP/AVP 0 8 101\r\n"
+                        << "m=audio " << LOCAL_RTP_PORT << " RTP/AVP 0 8\r\n"
                         // << "a=sendrecv\r\n"
                         << "a=recvonly\r\n"
-                        << "a=rtpmap:101 telephone-event/8000\r\n"
-                        << "a=fmtp:101 0-15\r\n"
                         << "a=ptime:20\r\n";
 
         tx_buffer << "Content-Length: " << m_tx_sdp_buffer.size() << "\r\n";


### PR DESCRIPTION
When the ESP32 initiates a call it sends an INVITE with a=recvonly. Including telephone-event (payload type 101) in the SDP offer may cause the Fritzbox to deliver DTMF as RFC 2833 RTP packets, which the firmware silently discarded — so the open-door function never triggered.

Removing telephone-event from the SDP offer leaves the phone with no RTP mechanism for DTMF, so it falls back to SIP INFO (application/dtmf-relay), which is already handled. This is the same path that works for incoming calls.

This may fix #43.